### PR TITLE
Create Ptp2FrameReader interface

### DIFF
--- a/pkg/ptp/frame.go
+++ b/pkg/ptp/frame.go
@@ -2,7 +2,7 @@
 *                                                                              *
 *  pkg/ptp/frame.go                                                            *
 *                                                                              *
-*  Defines a ptp2Frame, the basic unit of PTPv2 payload data. Provides         *
+*  Defines a Ptp2Frame, the basic unit of PTPv2 payload data. Provides         *
 *  utilities for encoding and decoding data frames from big-endian byte        *
 *  slices.                                                                     *
 *                                                                              *
@@ -41,7 +41,7 @@ const (
 )
 
 // Minimal unit of PTPv2 payload data
-type ptp2Frame struct {
+type Ptp2Frame struct {
 	Type      MsgType // Sync, FollowUp, DelayReq, DelayResp
 	Sequence  uint16  // Sequence ID for matching msgs
 	Timestamp uint64  // nanoseconds timestamp ptp t1 (FUp) or t3 (DelayResp)
@@ -51,8 +51,8 @@ type ptp2Frame struct {
 *  FUNCTION DEFINITIONS                                                        *
 *******************************************************************************/
 
-// Encode serializes a ptp2Frame into a fixed-length big-endian byte slice
-func Encode(f ptp2Frame) []byte {
+// Encode serializes a Ptp2Frame into a fixed-length big-endian byte slice
+func Encode(f Ptp2Frame) []byte {
 	buf := make([]byte, 1+2+8)
 	buf[0] = byte(f.Type)
 	binary.BigEndian.PutUint16(buf[1:], f.Sequence)
@@ -60,12 +60,12 @@ func Encode(f ptp2Frame) []byte {
 	return buf
 }
 
-// Decode parses a ptp2Frame from a big-endian byte slice
-func Decode(data []byte) (ptp2Frame, error) {
+// Decode parses a Ptp2Frame from a big-endian byte slice
+func Decode(data []byte) (Ptp2Frame, error) {
 	if len(data) < 11 {
-		return ptp2Frame{}, errors.New("ptp: frame too short")
+		return Ptp2Frame{}, errors.New("ptp: frame too short")
 	}
-	return ptp2Frame{
+	return Ptp2Frame{
 		Type:      MsgType(data[0]),
 		Sequence:  binary.BigEndian.Uint16(data[1:3]),
 		Timestamp: binary.BigEndian.Uint64(data[3:11]),

--- a/pkg/ptp/frame_test.go
+++ b/pkg/ptp/frame_test.go
@@ -2,7 +2,7 @@
 *                                                                              *
 *  pkg/ptp/frame_test.go                                                       *
 *                                                                              *
-*  Performs unit testing on the ptp2Frame object. Verifies that the object     *
+*  Performs unit testing on the Ptp2Frame object. Verifies that the object     *
 *  can be constructed, populated, encoded, and decoded correctly.              *
 *                                                                              *
 *  Author:   Edward Speer                                                      *
@@ -33,7 +33,7 @@ import (
 // Tests that a user may construct a frame with data
 func TestConstructFrame(t *testing.T) {
 	// Construct a simple frame
-	frame := ptp2Frame{
+	frame := Ptp2Frame{
 		Type:      Sync,
 		Sequence:  0xBEEF,
 		Timestamp: 0x1234567890ABCDEF,
@@ -53,7 +53,7 @@ func TestConstructFrame(t *testing.T) {
 // Tests that a user may encode and decode a frame
 func TestEncodeDecodeFrame(t *testing.T) {
 	// Construct a test frame
-	origin := ptp2Frame{
+	origin := Ptp2Frame{
 		Type:      Sync,
 		Sequence:  0xBEEF,
 		Timestamp: 0x1234567890ABCDEF,

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -1,14 +1,13 @@
 package reader
 
 import (
-    "time"
+	"time"
 
-    "github.com/Espeer5/ptp2go/pkg/ptp"
+	"github.com/Espeer5/ptp2go/pkg/ptp"
 )
 
-// ptp2FrameReader is an interface for receiving PTPv2 frames from any source
+// Ptp2FrameReader is an interface for receiving PTPv2 frames from any source
 // ReadFrame returns the next decoded from, local revieve timestamp, or err
-type FrameReader interface {
-    ReadFrame() (ptp.PtpFrame, time.Time, error)
+type Ptp2FrameReader interface {
+	ReadFrame() (ptp.Ptp2Frame, time.Time, error)
 }
-

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -1,0 +1,14 @@
+package reader
+
+import (
+    "time"
+
+    "github.com/Espeer5/ptp2go/pkg/ptp"
+)
+
+// ptp2FrameReader is an interface for receiving PTPv2 frames from any source
+// ReadFrame returns the next decoded from, local revieve timestamp, or err
+type FrameReader interface {
+    ReadFrame() (ptp.PtpFrame, time.Time, error)
+}
+

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -1,4 +1,25 @@
+/*******************************************************************************
+*                                                                              *
+*  pkg/reader/reader.go                                                        *
+*                                                                              *
+*  Defines the Ptp2FrameReader interface which reads in payloads from any ptp  *
+*  data source, constructs it into a Ptp2Frame, and passes it along to the     *
+*  backend.                                                                    *
+*                                                                              *
+*  Author:   Edward Speer                                                      *
+*  Revised: 7/16/2025                                                          *
+*                                                                              *
+*******************************************************************************/
+
+/*******************************************************************************
+*  PACKAGE DECLARATION                                                         *
+*******************************************************************************/
+
 package reader
+
+/*******************************************************************************
+*  IMPORTS                                                                     *
+*******************************************************************************/
 
 import (
 	"time"
@@ -6,8 +27,13 @@ import (
 	"github.com/Espeer5/ptp2go/pkg/ptp"
 )
 
+/*******************************************************************************
+*  TYPE DEFINITIONS                                                            *
+*******************************************************************************/
+
 // Ptp2FrameReader is an interface for receiving PTPv2 frames from any source
 // ReadFrame returns the next decoded from, local revieve timestamp, or err
 type Ptp2FrameReader interface {
+	// Read a frame from a source into a Ptp2Frame
 	ReadFrame() (ptp.Ptp2Frame, time.Time, error)
 }


### PR DESCRIPTION
Creates a very simple transport abstraction in the form of an interface for a PTPv2 frame reader. The role of a frame reader is to read frames from an input source, construct the `Ptp2Frame` typed defined in #10, and then pass the frame along to
the backend.

This will close #5, and clear the way to tackle #6.