### PR TITLE
Initialize Ptp2Handler struct and unit tests

### DIFF
--- a/pkg/ptp/frame.go
+++ b/pkg/ptp/frame.go
@@ -6,7 +6,7 @@
 *  utilities for encoding and decoding data frames from big-endian byte        *
 *  slices.                                                                     *
 *                                                                              *
-*  Author:   Edward Speer                                                      *
+*  Author:  Edward Speer                                                      *
 *  Revised: 7/16/2025                                                          *
 *                                                                              *
 *******************************************************************************/

--- a/pkg/ptp/frame_test.go
+++ b/pkg/ptp/frame_test.go
@@ -5,7 +5,7 @@
 *  Performs unit testing on the Ptp2Frame object. Verifies that the object     *
 *  can be constructed, populated, encoded, and decoded correctly.              *
 *                                                                              *
-*  Author:   Edward Speer                                                      *
+*  Author:  Edward Speer                                                      *
 *  Revised: 7/16/2025                                                          *
 *                                                                              *
 *******************************************************************************/

--- a/pkg/ptp/handler.go
+++ b/pkg/ptp/handler.go
@@ -1,0 +1,74 @@
+/*******************************************************************************
+*                                                                              *
+*  pkg/ptp/frame.go                                                            *
+*                                                                              *
+*  Defines the Ptp2Handler struct, which runs the PTPv2 state machine.         *
+*  Responds to incoming PTPv2 data payloads and sends out its own data to      *
+*  implement the ptp function via an internal state machine.                   *
+*                                                                              *
+*  Author:  Edward Speer                                                       *
+*  Revised: 7/17/2025                                                          *
+*                                                                              *
+*******************************************************************************/
+
+/*******************************************************************************
+*  PACKAGE DECLARATION                                                         *
+*******************************************************************************/
+
+package ptp
+
+/*******************************************************************************
+*  IMPORTS                                                                     *
+*******************************************************************************/
+
+import (
+	"sync"
+	"time"
+)
+
+/*******************************************************************************
+*  TYPE DEFINITIONS                                                            *
+*******************************************************************************/
+
+// Ptp2Handler contains the state necessary to match and compute PTPv2 exchanges
+type Ptp2Handler struct {
+	lock sync.Mutex
+
+	// The state for the most recent Sync+FollowUp sequence
+	lastSync struct {
+		seq      uint16
+		t1recv   time.Time // local receive time of Sync
+		t1p      uint64    // master timestamp from FollowUp
+		have_fUp bool      // Has received matching FollowUp message
+	}
+}
+
+// Constructor
+func NewPtp2Handler() *Ptp2Handler {
+	return &Ptp2Handler{}
+}
+
+// Handle ingests one Ptp2Frame along with the local receive/send time.
+// For Sync/fUp it records t1, DelayRequest records t2, DelayResp computes
+// offset and delay and calls report()
+func (h *Ptp2Handler) Handle(frame Ptp2Frame, localTIme time.Time) error {
+	// Protect the handler state via mutex until the end of the function call
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	// TODO: Implement PTPV2 state machine & compute offset/delay
+	// This line is a placeholder to appease linter
+	h.report(time.Duration(h.lastSync.t1p), time.Duration(h.lastSync.t1p))
+
+	return nil
+}
+
+// report is a private method of the PTP2Handler which directs the offset and
+// delay time to the configured output to allow usage of the timing data. For
+// example this function could be used to direct the offset and delay
+// information to an OCXO chip or other for clock synch
+func (h *Ptp2Handler) report(offset, delay time.Duration) {
+	println("OFFSET: ", offset.String(), ", DELAY: ", delay.String())
+
+	// TODO: Provide output stream capability
+}

--- a/pkg/ptp/handler_test.go
+++ b/pkg/ptp/handler_test.go
@@ -1,0 +1,100 @@
+/*******************************************************************************
+*                                                                              *
+*  pkg/ptp/handler_test.go                                                     *
+*                                                                              *
+*  Performs unit testing on the Ptp2Handler objects. Verifies that the         *
+*  handler behaves as expected to implement the ptp function.                  *
+*                                                                              *
+*  Author:  Edward Speer                                                       *
+*  Revised: 7/17/2025                                                          *
+*                                                                              *
+*******************************************************************************/
+
+/*******************************************************************************
+*  PACKAGE DECLARATION                                                         *
+*******************************************************************************/
+
+package ptp
+
+/*******************************************************************************
+*  IMPORTS                                                                     *
+*******************************************************************************/
+
+import (
+	// Testing utilities
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	// stdlib
+	"time"
+)
+
+/*******************************************************************************
+*  UNIT TESTS                                                                  *
+*******************************************************************************/
+
+// Tests that a user may instantiate a new Ptp2Handler and populate its fields
+func TestConstructHandler(t *testing.T) {
+	// Use the provided handler constructor
+	handler := NewPtp2Handler()
+
+	// Create a time for the latest Sync
+	t1recv := time.Date(
+		2025,        // year
+		time.July,   // month
+		17,          // day
+		13,          // hour
+		30,          // minute
+		45,          // second
+		123_456_789, // nanosecond
+		time.UTC,    // location
+	)
+
+	// Populate all data in the handler
+	handler.lastSync.seq = 0x01
+	handler.lastSync.t1recv = t1recv
+	handler.lastSync.t1p = 0xBEEF
+	handler.lastSync.have_fUp = true
+
+	// Attempt locking the handler
+	handler.lock.Lock()
+	defer handler.lock.Unlock()
+
+	// Check that the data is correct
+	assert.Equal(t, handler.lastSync.seq, uint16(0x01), "Incorrect Seq Num set")
+	assert.Equal(t, handler.lastSync.t1recv, t1recv, "t1recv cannot init")
+	assert.Equal(t, handler.lastSync.t1p, uint64(0xBEEF), "Cannot init t1")
+	assert.Equal(t, handler.lastSync.have_fUp, true, "Cannot set have_fUp")
+}
+
+// Tests that alling Handler() does not throw an error
+func TestHandleValid(t *testing.T) {
+	// Construct a new handler
+	handler := NewPtp2Handler()
+
+	// Create a new Ptp2Frame to call handler.Handle() on
+	frame := Ptp2Frame{
+		Type:      Sync,
+		Sequence:  0xBEEF,
+		Timestamp: 0x1234567890ABCDEF,
+	}
+
+	// Create a local time to pass to handler.Handle()
+	local_time := time.Date(
+		2025,        // year
+		time.July,   // month
+		17,          // day
+		13,          // hour
+		30,          // minute
+		45,          // second
+		123_456_789, // nanosecond
+		time.UTC,    // location
+	)
+
+	// Attempt to call Handle
+	err := handler.Handle(frame, local_time)
+
+	// Ensure no error was thrown
+	assert.NoError(t, err)
+}

--- a/pkg/reader/reader.go
+++ b/pkg/reader/reader.go
@@ -6,7 +6,7 @@
 *  data source, constructs it into a Ptp2Frame, and passes it along to the     *
 *  backend.                                                                    *
 *                                                                              *
-*  Author:   Edward Speer                                                      *
+*  Author:  Edward Speer                                                      *
 *  Revised: 7/16/2025                                                          *
 *                                                                              *
 *******************************************************************************/


### PR DESCRIPTION
Adds the stub of the `Ptp2Handler` struct with placeholders for PTP state machine and reporting functionalities. Will close #12. Also creates minimal unit tests for the struct to be extended as the state machine and reporting are completed. 